### PR TITLE
Only getConnection when logging enabled

### DIFF
--- a/config-instance.example.toml
+++ b/config-instance.example.toml
@@ -27,7 +27,7 @@ bannedHostnames = [
 ]
 
 ###
-# MySQL is used for Logging wnen it is enabled
+# MySQL is used for Logging when it is enabled
 ###
 [mysql]
 host = 'localhost'

--- a/src/logging/log-telemetry-message.ts
+++ b/src/logging/log-telemetry-message.ts
@@ -4,12 +4,13 @@ import { Message } from "../telemetry/message";
 import { getConnection } from "../mysql/connection";
 
 const logTelemetryMessage = async function(message: Message) {
-    const connection = await getConnection();
     const enableLogging = config.runtime.enableLogging ?? false;
 
     if (!enableLogging) {
         return;
     }
+
+    const connection = await getConnection();
 
     const date = moment().tz('Australia/Sydney').format('YYYY-MM-DD HH:mm:ss');
     const sql = `

--- a/src/metrics/add-client-log.ts
+++ b/src/metrics/add-client-log.ts
@@ -3,12 +3,13 @@ import config from "../../config";
 import { getConnection } from "../mysql/connection";
 
 export default async function addClientLog(clientId: string, eventKey: string, eventValue: string): Promise<void> {
-    const connection = await getConnection();
     const enableLogging = config.runtime.enableLogging ?? false;
 
     if (!enableLogging) {
         return;
     }
+
+    const connection = await getConnection();
 
     const date = moment().tz('Australia/Sydney').format('YYYY-MM-DD HH:mm:ss');
     await connection.query(


### PR DESCRIPTION
Small improvement to only getConnection if logging is enabled. 

Helps with local development, too, because you can get the server running without having to run mysql db.