### PR TITLE
Specify whether API key auth is required

### DIFF
--- a/config-instance.example.toml
+++ b/config-instance.example.toml
@@ -26,6 +26,9 @@ bannedHostnames = [
     'evil.com'
 ]
 
+# Specify whether connections need API key
+authorizationRequired = true
+
 ###
 # MySQL is used for Logging wnen it is enabled
 ###


### PR DESCRIPTION
Make API key auth configurable for 
- local development 
- self-hosted versions that don't want to use API key auth